### PR TITLE
Force root

### DIFF
--- a/sh/gnb_freebsd_amd64.sh
+++ b/sh/gnb_freebsd_amd64.sh
@@ -21,6 +21,10 @@ GNB_BINARY=FreeBSD_amd64
 gnb_op_cmd=$1
 gnb_nodeid=$2
 
+if [ "$USER" != "root" ]; then
+    sudo $0 $*
+    exit $?
+fi
 
 show_usage(){
    echo "usage: $0 start|stop|restart node"

--- a/sh/gnb_freebsd_amd64.sh
+++ b/sh/gnb_freebsd_amd64.sh
@@ -27,65 +27,64 @@ if [ "$USER" != "root" ]; then
 fi
 
 show_usage(){
-   echo "usage: $0 start|stop|restart node"
-   echo "example: $0 start" 1001
-   echo "node located: [${GNB_DIR}/conf/]"
-   ls ${GNB_DIR}/conf/
+    echo "usage: $0 start|stop|restart node"
+    echo "example: $0 start" 1001
+    echo "node located: [${GNB_DIR}/conf/]"
+    ls ${GNB_DIR}/conf/
 }
 
 
 start_gnb() {
     nohup ${GNB_DIR}/bin/$GNB_BINARY/gnb_es -s -b "${GNB_DIR}/conf/$gnb_nodeid/gnb.map" --dump-address --upnp --pid-file=${GNB_DIR}/conf/$gnb_nodeid/gnb_es.pid    > /dev/null 2>&1 &
-	nohup ${GNB_DIR}/bin/$GNB_BINARY/gnb -i "GNB_TUN_$gnb_nodeid" -c "${GNB_DIR}/conf/$gnb_nodeid" --port_detect_start=1000 --port_detect_end=65535  > /dev/null 2>&1 &
+    nohup ${GNB_DIR}/bin/$GNB_BINARY/gnb -i "GNB_TUN_$gnb_nodeid" -c "${GNB_DIR}/conf/$gnb_nodeid" --port_detect_start=1000 --port_detect_end=65535  > /dev/null 2>&1 &
 }
 
 
 debug_gnb(){
     nohup ${GNB_DIR}/bin/$GNB_BINARY/gnb_es -s -b "${GNB_DIR}/conf/$gnb_nodeid/gnb.map" --dump-address --upnp     > /dev/null 2>&1 &
-	${GNB_DIR}/bin/$GNB_BINARY/gnb -i "GNB_TUN_$gnb_nodeid" -c "${GNB_DIR}/conf/$gnb_nodeid" --port_detect_start=1000 --port_detect_end=65535 --set-if-dump=on
+    ${GNB_DIR}/bin/$GNB_BINARY/gnb -i "GNB_TUN_$gnb_nodeid" -c "${GNB_DIR}/conf/$gnb_nodeid" --port_detect_start=1000 --port_detect_end=65535 --set-if-dump=on
 }
 
 stop_gnb() {
-	#kill -9 `cat ${GNB_DIR}/conf/$gnb_nodeid/gnb_es.pid`
-	#kill -9 `cat ${GNB_DIR}/conf/$gnb_nodeid/gnb.pid`
-	killall -9 gnb
-	killall -9 gnb_es
+    #kill -9 `cat ${GNB_DIR}/conf/$gnb_nodeid/gnb_es.pid`
+    #kill -9 `cat ${GNB_DIR}/conf/$gnb_nodeid/gnb.pid`
+    killall -9 gnb
+    killall -9 gnb_es
 }
 
-
 if [ -z "$gnb_op_cmd" ] || [ -z "$gnb_nodeid" ]; then
-	show_usage
-	exit;
+    show_usage
+    exit;
 fi
 
 
 if [ ! -d "${GNB_DIR}/conf/$gnb_nodeid" ]; then
-	echo "node '$gnb_nodeid' directory '${GNB_DIR}/conf/$gnb_nodeid' not found"
-	exit;
+    echo "node '$gnb_nodeid' directory '${GNB_DIR}/conf/$gnb_nodeid' not found"
+    exit;
 fi
 
 
 if [ "$gnb_op_cmd" = "stop" ] ; then
 
-	stop_gnb
+    stop_gnb
 
 elif [ "$gnb_op_cmd" = "restart" ]; then
 
-	stop_gnb
-	start_gnb
+    stop_gnb
+    start_gnb
 
 elif [ "$gnb_op_cmd" = "debug" ]; then
 
-	stop_gnb
-	debug_gnb
+    stop_gnb
+    debug_gnb
 
 elif [ "$gnb_op_cmd" = "start" ]; then
 
-	start_gnb
+    start_gnb
 
 elif [ "$gnb_op_cmd" = "start" ]; then
 
-	debug_gnb
+    debug_gnb
 
 fi
 

--- a/sh/gnb_linux_x86_64.sh
+++ b/sh/gnb_linux_x86_64.sh
@@ -22,6 +22,11 @@ GNB_BINARY=Linux_x86_64
 gnb_op_cmd=$1
 gnb_nodeid=$2
 
+if [ "$USER" != "root" ]; then
+    sudo $0 $*
+    exit $?
+fi
+
 show_usage(){
    echo "usage: $0 start|stop|restart node"
    echo "example: $0 start" 1001

--- a/sh/gnb_linux_x86_64.sh
+++ b/sh/gnb_linux_x86_64.sh
@@ -28,65 +28,64 @@ if [ "$USER" != "root" ]; then
 fi
 
 show_usage(){
-   echo "usage: $0 start|stop|restart node"
-   echo "example: $0 start" 1001
-   echo "node located: [${GNB_DIR}/conf/]"
-   ls ${GNB_DIR}/conf/
+    echo "usage: $0 start|stop|restart node"
+    echo "example: $0 start" 1001
+    echo "node located: [${GNB_DIR}/conf/]"
+    ls ${GNB_DIR}/conf/
 }
 
 
 start_gnb() {
     nohup ${GNB_DIR}/bin/$GNB_BINARY/gnb_es -s -b "${GNB_DIR}/conf/$gnb_nodeid/gnb.map" --dump-address --upnp --pid-file=${GNB_DIR}/conf/$gnb_nodeid/gnb_es.pid    > /dev/null 2>&1 &
-	nohup ${GNB_DIR}/bin/$GNB_BINARY/gnb -i "GNB_TUN_$gnb_nodeid" -c "${GNB_DIR}/conf/$gnb_nodeid" --port_detect_start=1000 --port_detect_end=65535  > /dev/null 2>&1 &
+    nohup ${GNB_DIR}/bin/$GNB_BINARY/gnb -i "GNB_TUN_$gnb_nodeid" -c "${GNB_DIR}/conf/$gnb_nodeid" --port_detect_start=1000 --port_detect_end=65535  > /dev/null 2>&1 &
 }
 
 
 debug_gnb(){
     nohup ${GNB_DIR}/bin/$GNB_BINARY/gnb_es -s -b "${GNB_DIR}/conf/$gnb_nodeid/gnb.map" --dump-address --upnp     > /dev/null 2>&1 &
-	${GNB_DIR}/bin/$GNB_BINARY/gnb -i "GNB_TUN_$gnb_nodeid" -c "${GNB_DIR}/conf/$gnb_nodeid" --port_detect_start=1000 --port_detect_end=65535 --set-if-dump=on
+    ${GNB_DIR}/bin/$GNB_BINARY/gnb -i "GNB_TUN_$gnb_nodeid" -c "${GNB_DIR}/conf/$gnb_nodeid" --port_detect_start=1000 --port_detect_end=65535 --set-if-dump=on
 }
 
 stop_gnb() {
-	#kill -9 `cat ${GNB_DIR}/conf/$gnb_nodeid/gnb_es.pid`
-	#kill -9 `cat ${GNB_DIR}/conf/$gnb_nodeid/gnb.pid`
-	killall -9 gnb
-	killall -9 gnb_es
+    #kill -9 `cat ${GNB_DIR}/conf/$gnb_nodeid/gnb_es.pid`
+    #kill -9 `cat ${GNB_DIR}/conf/$gnb_nodeid/gnb.pid`
+    killall -9 gnb
+    killall -9 gnb_es
 }
 
-
 if [ -z "$gnb_op_cmd" ] || [ -z "$gnb_nodeid" ]; then
-	show_usage
-	exit;
+    show_usage
+    exit;
 fi
 
 
 if [ ! -d "${GNB_DIR}/conf/$gnb_nodeid" ]; then
-	echo "node '$gnb_nodeid' directory '${GNB_DIR}/conf/$gnb_nodeid' not found"
-	exit;
+    echo "node '$gnb_nodeid' directory '${GNB_DIR}/conf/$gnb_nodeid' not found"
+    exit;
 fi
 
 
 if [ "$gnb_op_cmd" = "stop" ] ; then
 
-	stop_gnb
+    stop_gnb
 
 elif [ "$gnb_op_cmd" = "restart" ]; then
 
-	stop_gnb
-	start_gnb
+    stop_gnb
+    start_gnb
 
 elif [ "$gnb_op_cmd" = "debug" ]; then
 
-	stop_gnb
-	debug_gnb
+    stop_gnb
+    debug_gnb
 
 elif [ "$gnb_op_cmd" = "start" ]; then
 
-	start_gnb
+    start_gnb
 
 elif [ "$gnb_op_cmd" = "start" ]; then
 
-	debug_gnb
+    debug_gnb
 
 fi
 

--- a/sh/gnb_macOS.sh
+++ b/sh/gnb_macOS.sh
@@ -37,13 +37,13 @@ show_usage(){
 
 
 start_gnb() {
-    nohup ${GNB_DIR}/bin/$GNB_BINARY/gnb_es -s -b "${GNB_DIR}/conf/$gnb_nodeid/gnb.map" --dump-address --upnp --pid-file=${GNB_DIR}/conf/$gnb_nodeid/gnb_es.pid    > /dev/null 2>&1 &
-    nohup ${GNB_DIR}/bin/$GNB_BINARY/gnb -i "GNB_TUN_$gnb_nodeid" -c "${GNB_DIR}/conf/$gnb_nodeid" --port_detect_start=1000 --port_detect_end=65535  > /dev/null 2>&1 &
+    ${GNB_DIR}/bin/$GNB_BINARY/gnb_es -s -b "${GNB_DIR}/conf/$gnb_nodeid/gnb.map" --dump-address --upnp --pid-file=${GNB_DIR}/conf/$gnb_nodeid/gnb_es.pid    > /dev/null 2>&1 &
+    ${GNB_DIR}/bin/$GNB_BINARY/gnb -i "GNB_TUN_$gnb_nodeid" -c "${GNB_DIR}/conf/$gnb_nodeid" --port_detect_start=1000 --port_detect_end=65535  > /dev/null 2>&1 &
 }
 
 
 debug_gnb(){
-    nohup ${GNB_DIR}/bin/$GNB_BINARY/gnb_es -s -b "${GNB_DIR}/conf/$gnb_nodeid/gnb.map" --dump-address --upnp     > /dev/null 2>&1 &
+    ${GNB_DIR}/bin/$GNB_BINARY/gnb_es -s -b "${GNB_DIR}/conf/$gnb_nodeid/gnb.map" --dump-address --upnp     > /dev/null 2>&1 &
     ${GNB_DIR}/bin/$GNB_BINARY/gnb -i "GNB_TUN_$gnb_nodeid" -c "${GNB_DIR}/conf/$gnb_nodeid" --port_detect_start=1000 --port_detect_end=65535 --set-if-dump=on
 }
 

--- a/sh/gnb_macOS.sh
+++ b/sh/gnb_macOS.sh
@@ -29,66 +29,66 @@ if [ "$USER" != "root" ]; then
 fi
 
 show_usage(){
-   echo "usage: $0 start|stop|restart node"
-   echo "example: $0 start" 1001
-   echo "node located: [${GNB_DIR}/conf/]"
-   ls ${GNB_DIR}/conf/
+    echo "usage: $0 start|stop|restart node"
+    echo "example: $0 start" 1001
+    echo "node located: [${GNB_DIR}/conf/]"
+    ls ${GNB_DIR}/conf/
 }
 
 
 start_gnb() {
     nohup ${GNB_DIR}/bin/$GNB_BINARY/gnb_es -s -b "${GNB_DIR}/conf/$gnb_nodeid/gnb.map" --dump-address --upnp --pid-file=${GNB_DIR}/conf/$gnb_nodeid/gnb_es.pid    > /dev/null 2>&1 &
-	nohup ${GNB_DIR}/bin/$GNB_BINARY/gnb -i "GNB_TUN_$gnb_nodeid" -c "${GNB_DIR}/conf/$gnb_nodeid" --port_detect_start=1000 --port_detect_end=65535  > /dev/null 2>&1 &
+    nohup ${GNB_DIR}/bin/$GNB_BINARY/gnb -i "GNB_TUN_$gnb_nodeid" -c "${GNB_DIR}/conf/$gnb_nodeid" --port_detect_start=1000 --port_detect_end=65535  > /dev/null 2>&1 &
 }
 
 
 debug_gnb(){
     nohup ${GNB_DIR}/bin/$GNB_BINARY/gnb_es -s -b "${GNB_DIR}/conf/$gnb_nodeid/gnb.map" --dump-address --upnp     > /dev/null 2>&1 &
-	${GNB_DIR}/bin/$GNB_BINARY/gnb -i "GNB_TUN_$gnb_nodeid" -c "${GNB_DIR}/conf/$gnb_nodeid" --port_detect_start=1000 --port_detect_end=65535 --set-if-dump=on
+    ${GNB_DIR}/bin/$GNB_BINARY/gnb -i "GNB_TUN_$gnb_nodeid" -c "${GNB_DIR}/conf/$gnb_nodeid" --port_detect_start=1000 --port_detect_end=65535 --set-if-dump=on
 }
 
 stop_gnb() {
-	#kill -9 `cat ${GNB_DIR}/conf/$gnb_nodeid/gnb_es.pid`
-	#kill -9 `cat ${GNB_DIR}/conf/$gnb_nodeid/gnb.pid`
-	killall -9 gnb
-	killall -9 gnb_es
+    #kill -9 `cat ${GNB_DIR}/conf/$gnb_nodeid/gnb_es.pid`
+    #kill -9 `cat ${GNB_DIR}/conf/$gnb_nodeid/gnb.pid`
+    killall -9 gnb
+    killall -9 gnb_es
 }
 
 root_check
 
 if [ -z "$gnb_op_cmd" ] || [ -z "$gnb_nodeid" ]; then
-	show_usage
-	exit;
+    show_usage
+    exit;
 fi
 
 
 if [ ! -d "${GNB_DIR}/conf/$gnb_nodeid" ]; then
-	echo "node '$gnb_nodeid' directory '${GNB_DIR}/conf/$gnb_nodeid' not found"
-	exit;
+    echo "node '$gnb_nodeid' directory '${GNB_DIR}/conf/$gnb_nodeid' not found"
+    exit;
 fi
 
 
 if [ "$gnb_op_cmd" = "stop" ] ; then
 
-	stop_gnb
+    stop_gnb
 
 elif [ "$gnb_op_cmd" = "restart" ]; then
 
-	stop_gnb
-	start_gnb
+    stop_gnb
+    start_gnb
 
 elif [ "$gnb_op_cmd" = "debug" ]; then
 
-	stop_gnb
-	debug_gnb
+    stop_gnb
+    debug_gnb
 
 elif [ "$gnb_op_cmd" = "start" ]; then
 
-	start_gnb
+    start_gnb
 
 elif [ "$gnb_op_cmd" = "start" ]; then
 
-	debug_gnb
+    debug_gnb
 
 fi
 

--- a/sh/gnb_macOS.sh
+++ b/sh/gnb_macOS.sh
@@ -23,6 +23,11 @@ GNB_BINARY=macOS
 gnb_op_cmd=$1
 gnb_nodeid=$2
 
+if [ "$USER" != "root" ]; then
+    sudo $0 $*
+    exit $?
+fi
+
 show_usage(){
    echo "usage: $0 start|stop|restart node"
    echo "example: $0 start" 1001
@@ -49,6 +54,7 @@ stop_gnb() {
 	killall -9 gnb_es
 }
 
+root_check
 
 if [ -z "$gnb_op_cmd" ] || [ -z "$gnb_nodeid" ]; then
 	show_usage

--- a/sh/gnb_openbsd_amd64.sh
+++ b/sh/gnb_openbsd_amd64.sh
@@ -28,65 +28,65 @@ if [ "$USER" != "root" ]; then
 fi
 
 show_usage(){
-   echo "usage: $0 start|stop|restart node"
-   echo "example: $0 start" 1001
-   echo "node located: [${GNB_DIR}/conf/]"
-   ls ${GNB_DIR}/conf/
+    echo "usage: $0 start|stop|restart node"
+    echo "example: $0 start" 1001
+    echo "node located: [${GNB_DIR}/conf/]"
+    ls ${GNB_DIR}/conf/
 }
 
 
 start_gnb() {
     nohup ${GNB_DIR}/bin/$GNB_BINARY/gnb_es -s -b "${GNB_DIR}/conf/$gnb_nodeid/gnb.map" --dump-address --upnp --pid-file=${GNB_DIR}/conf/$gnb_nodeid/gnb_es.pid    > /dev/null 2>&1 &
-	nohup ${GNB_DIR}/bin/$GNB_BINARY/gnb -i "GNB_TUN_$gnb_nodeid" -c "${GNB_DIR}/conf/$gnb_nodeid" --port_detect_start=1000 --port_detect_end=65535  > /dev/null 2>&1 &
+    nohup ${GNB_DIR}/bin/$GNB_BINARY/gnb -i "GNB_TUN_$gnb_nodeid" -c "${GNB_DIR}/conf/$gnb_nodeid" --port_detect_start=1000 --port_detect_end=65535  > /dev/null 2>&1 &
 }
 
 
 debug_gnb(){
     nohup ${GNB_DIR}/bin/$GNB_BINARY/gnb_es -s -b "${GNB_DIR}/conf/$gnb_nodeid/gnb.map" --dump-address --upnp     > /dev/null 2>&1 &
-	${GNB_DIR}/bin/$GNB_BINARY/gnb -i "GNB_TUN_$gnb_nodeid" -c "${GNB_DIR}/conf/$gnb_nodeid" --port_detect_start=1000 --port_detect_end=65535 --set-if-dump=on
+    ${GNB_DIR}/bin/$GNB_BINARY/gnb -i "GNB_TUN_$gnb_nodeid" -c "${GNB_DIR}/conf/$gnb_nodeid" --port_detect_start=1000 --port_detect_end=65535 --set-if-dump=on
 }
 
 stop_gnb() {
-	#kill -9 `cat ${GNB_DIR}/conf/$gnb_nodeid/gnb_es.pid`
-	#kill -9 `cat ${GNB_DIR}/conf/$gnb_nodeid/gnb.pid`
-	killall -9 gnb
-	killall -9 gnb_es
+    #kill -9 `cat ${GNB_DIR}/conf/$gnb_nodeid/gnb_es.pid`
+    #kill -9 `cat ${GNB_DIR}/conf/$gnb_nodeid/gnb.pid`
+    killall -9 gnb
+    killall -9 gnb_es
 }
 
 
 if [ -z "$gnb_op_cmd" ] || [ -z "$gnb_nodeid" ]; then
-	show_usage
-	exit;
+    show_usage
+    exit;
 fi
 
 
 if [ ! -d "${GNB_DIR}/conf/$gnb_nodeid" ]; then
-	echo "node '$gnb_nodeid' directory '${GNB_DIR}/conf/$gnb_nodeid' not found"
-	exit;
+    echo "node '$gnb_nodeid' directory '${GNB_DIR}/conf/$gnb_nodeid' not found"
+    exit;
 fi
 
 
 if [ "$gnb_op_cmd" = "stop" ] ; then
 
-	stop_gnb
+    stop_gnb
 
 elif [ "$gnb_op_cmd" = "restart" ]; then
 
-	stop_gnb
-	start_gnb
+    stop_gnb
+    start_gnb
 
 elif [ "$gnb_op_cmd" = "debug" ]; then
 
-	stop_gnb
-	debug_gnb
+    stop_gnb
+    debug_gnb
 
 elif [ "$gnb_op_cmd" = "start" ]; then
 
-	start_gnb
+    start_gnb
 
 elif [ "$gnb_op_cmd" = "start" ]; then
 
-	debug_gnb
+    debug_gnb
 
 fi
 

--- a/sh/gnb_openbsd_amd64.sh
+++ b/sh/gnb_openbsd_amd64.sh
@@ -22,6 +22,10 @@ GNB_BINARY=OpenBSD_amd64
 gnb_op_cmd=$1
 gnb_nodeid=$2
 
+if [ "$USER" != "root" ]; then
+    sudo $0 $*
+    exit $?
+fi
 
 show_usage(){
    echo "usage: $0 start|stop|restart node"

--- a/sh/gnb_openwrt_1900acs.sh
+++ b/sh/gnb_openwrt_1900acs.sh
@@ -22,67 +22,66 @@ GNB_BINARY=openwrt/mvebu-cortexa9
 gnb_op_cmd=$1
 gnb_nodeid=$2
 
-
 show_usage(){
-   echo "usage: $0 start|stop|restart node"
-   echo "example: $0 start" 1001
-   echo "node located: [${GNB_DIR}/conf/]"
-   ls ${GNB_DIR}/conf/
+    echo "usage: $0 start|stop|restart node"
+    echo "example: $0 start" 1001
+    echo "node located: [${GNB_DIR}/conf/]"
+    ls ${GNB_DIR}/conf/
 }
 
 
 start_gnb() {
     nohup ${GNB_DIR}/bin/$GNB_BINARY/gnb_es -s -b "${GNB_DIR}/conf/$gnb_nodeid/gnb.map" --dump-address --upnp --pid-file=${GNB_DIR}/conf/$gnb_nodeid/gnb_es.pid    > /dev/null 2>&1 &
-	nohup ${GNB_DIR}/bin/$GNB_BINARY/gnb -i "GNB_TUN_$gnb_nodeid" -c "${GNB_DIR}/conf/$gnb_nodeid" --port_detect_start=1000 --port_detect_end=65535  > /dev/null 2>&1 &
+    nohup ${GNB_DIR}/bin/$GNB_BINARY/gnb -i "GNB_TUN_$gnb_nodeid" -c "${GNB_DIR}/conf/$gnb_nodeid" --port_detect_start=1000 --port_detect_end=65535  > /dev/null 2>&1 &
 }
 
 
 debug_gnb(){
     nohup ${GNB_DIR}/bin/$GNB_BINARY/gnb_es -s -b "${GNB_DIR}/conf/$gnb_nodeid/gnb.map" --dump-address --upnp     > /dev/null 2>&1 &
-	${GNB_DIR}/bin/$GNB_BINARY/gnb -i "GNB_TUN_$gnb_nodeid" -c "${GNB_DIR}/conf/$gnb_nodeid" --port_detect_start=1000 --port_detect_end=65535 --set-if-dump=on
+    ${GNB_DIR}/bin/$GNB_BINARY/gnb -i "GNB_TUN_$gnb_nodeid" -c "${GNB_DIR}/conf/$gnb_nodeid" --port_detect_start=1000 --port_detect_end=65535 --set-if-dump=on
 }
 
 stop_gnb() {
-	#kill -9 `cat ${GNB_DIR}/conf/$gnb_nodeid/gnb_es.pid`
-	#kill -9 `cat ${GNB_DIR}/conf/$gnb_nodeid/gnb.pid`
-	killall -9 gnb
-	killall -9 gnb_es
+    #kill -9 `cat ${GNB_DIR}/conf/$gnb_nodeid/gnb_es.pid`
+    #kill -9 `cat ${GNB_DIR}/conf/$gnb_nodeid/gnb.pid`
+    killall -9 gnb
+    killall -9 gnb_es
 }
 
 
 if [ -z "$gnb_op_cmd" ] || [ -z "$gnb_nodeid" ]; then
-	show_usage
-	exit;
+    show_usage
+    exit;
 fi
 
 
 if [ ! -d "${GNB_DIR}/conf/$gnb_nodeid" ]; then
-	echo "node '$gnb_nodeid' directory '${GNB_DIR}/conf/$gnb_nodeid' not found"
-	exit;
+    echo "node '$gnb_nodeid' directory '${GNB_DIR}/conf/$gnb_nodeid' not found"
+    exit;
 fi
 
 
 if [ "$gnb_op_cmd" = "stop" ] ; then
 
-	stop_gnb
+    stop_gnb
 
 elif [ "$gnb_op_cmd" = "restart" ]; then
 
-	stop_gnb
-	start_gnb
+    stop_gnb
+    start_gnb
 
 elif [ "$gnb_op_cmd" = "debug" ]; then
 
-	stop_gnb
-	debug_gnb
+    stop_gnb
+    debug_gnb
 
 elif [ "$gnb_op_cmd" = "start" ]; then
 
-	start_gnb
+    start_gnb
 
 elif [ "$gnb_op_cmd" = "start" ]; then
 
-	debug_gnb
+    debug_gnb
 
 fi
 

--- a/sh/gnb_openwrt_ar71xx-generic.sh
+++ b/sh/gnb_openwrt_ar71xx-generic.sh
@@ -22,67 +22,66 @@ GNB_BINARY=openwrt/ar71xx-generic
 gnb_op_cmd=$1
 gnb_nodeid=$2
 
-
 show_usage(){
-   echo "usage: $0 start|stop|restart node"
-   echo "example: $0 start" 1001
-   echo "node located: [${GNB_DIR}/conf/]"
-   ls ${GNB_DIR}/conf/
+    echo "usage: $0 start|stop|restart node"
+    echo "example: $0 start" 1001
+    echo "node located: [${GNB_DIR}/conf/]"
+    ls ${GNB_DIR}/conf/
 }
 
 
 start_gnb() {
     nohup ${GNB_DIR}/bin/$GNB_BINARY/gnb_es -s -b "${GNB_DIR}/conf/$gnb_nodeid/gnb.map" --dump-address --upnp --pid-file=${GNB_DIR}/conf/$gnb_nodeid/gnb_es.pid    > /dev/null 2>&1 &
-	nohup ${GNB_DIR}/bin/$GNB_BINARY/gnb -i "GNB_TUN_$gnb_nodeid" -c "${GNB_DIR}/conf/$gnb_nodeid" --port_detect_start=1000 --port_detect_end=65535  > /dev/null 2>&1 &
+    nohup ${GNB_DIR}/bin/$GNB_BINARY/gnb -i "GNB_TUN_$gnb_nodeid" -c "${GNB_DIR}/conf/$gnb_nodeid" --port_detect_start=1000 --port_detect_end=65535  > /dev/null 2>&1 &
 }
 
 
 debug_gnb(){
     nohup ${GNB_DIR}/bin/$GNB_BINARY/gnb_es -s -b "${GNB_DIR}/conf/$gnb_nodeid/gnb.map" --dump-address --upnp     > /dev/null 2>&1 &
-	${GNB_DIR}/bin/$GNB_BINARY/gnb -i "GNB_TUN_$gnb_nodeid" -c "${GNB_DIR}/conf/$gnb_nodeid" --port_detect_start=1000 --port_detect_end=65535 --set-if-dump=on
+    ${GNB_DIR}/bin/$GNB_BINARY/gnb -i "GNB_TUN_$gnb_nodeid" -c "${GNB_DIR}/conf/$gnb_nodeid" --port_detect_start=1000 --port_detect_end=65535 --set-if-dump=on
 }
 
 stop_gnb() {
-	#kill -9 `cat ${GNB_DIR}/conf/$gnb_nodeid/gnb_es.pid`
-	#kill -9 `cat ${GNB_DIR}/conf/$gnb_nodeid/gnb.pid`
-	killall -9 gnb
-	killall -9 gnb_es
+    #kill -9 `cat ${GNB_DIR}/conf/$gnb_nodeid/gnb_es.pid`
+    #kill -9 `cat ${GNB_DIR}/conf/$gnb_nodeid/gnb.pid`
+    killall -9 gnb
+    killall -9 gnb_es
 }
 
 
 if [ -z "$gnb_op_cmd" ] || [ -z "$gnb_nodeid" ]; then
-	show_usage
-	exit;
+    show_usage
+    exit;
 fi
 
 
 if [ ! -d "${GNB_DIR}/conf/$gnb_nodeid" ]; then
-	echo "node '$gnb_nodeid' directory '${GNB_DIR}/conf/$gnb_nodeid' not found"
-	exit;
+    echo "node '$gnb_nodeid' directory '${GNB_DIR}/conf/$gnb_nodeid' not found"
+    exit;
 fi
 
 
 if [ "$gnb_op_cmd" = "stop" ] ; then
 
-	stop_gnb
+    stop_gnb
 
 elif [ "$gnb_op_cmd" = "restart" ]; then
 
-	stop_gnb
-	start_gnb
+    stop_gnb
+    start_gnb
 
 elif [ "$gnb_op_cmd" = "debug" ]; then
 
-	stop_gnb
-	debug_gnb
+    stop_gnb
+    debug_gnb
 
 elif [ "$gnb_op_cmd" = "start" ]; then
 
-	start_gnb
+    start_gnb
 
 elif [ "$gnb_op_cmd" = "start" ]; then
 
-	debug_gnb
+    debug_gnb
 
 fi
 

--- a/sh/gnb_openwrt_ar71xx-nand.sh
+++ b/sh/gnb_openwrt_ar71xx-nand.sh
@@ -22,67 +22,66 @@ GNB_BINARY=openwrt/ar71xx-nand
 gnb_op_cmd=$1
 gnb_nodeid=$2
 
-
 show_usage(){
-   echo "usage: $0 start|stop|restart node"
-   echo "example: $0 start" 1001
-   echo "node located: [${GNB_DIR}/conf/]"
-   ls ${GNB_DIR}/conf/
+    echo "usage: $0 start|stop|restart node"
+    echo "example: $0 start" 1001
+    echo "node located: [${GNB_DIR}/conf/]"
+    ls ${GNB_DIR}/conf/
 }
 
 
 start_gnb() {
     nohup ${GNB_DIR}/bin/$GNB_BINARY/gnb_es -s -b "${GNB_DIR}/conf/$gnb_nodeid/gnb.map" --dump-address --upnp --pid-file=${GNB_DIR}/conf/$gnb_nodeid/gnb_es.pid    > /dev/null 2>&1 &
-	nohup ${GNB_DIR}/bin/$GNB_BINARY/gnb -i "GNB_TUN_$gnb_nodeid" -c "${GNB_DIR}/conf/$gnb_nodeid" --port_detect_start=1000 --port_detect_end=65535  > /dev/null 2>&1 &
+    nohup ${GNB_DIR}/bin/$GNB_BINARY/gnb -i "GNB_TUN_$gnb_nodeid" -c "${GNB_DIR}/conf/$gnb_nodeid" --port_detect_start=1000 --port_detect_end=65535  > /dev/null 2>&1 &
 }
 
 
 debug_gnb(){
     nohup ${GNB_DIR}/bin/$GNB_BINARY/gnb_es -s -b "${GNB_DIR}/conf/$gnb_nodeid/gnb.map" --dump-address --upnp     > /dev/null 2>&1 &
-	${GNB_DIR}/bin/$GNB_BINARY/gnb -i "GNB_TUN_$gnb_nodeid" -c "${GNB_DIR}/conf/$gnb_nodeid" --port_detect_start=1000 --port_detect_end=65535 --set-if-dump=on
+    ${GNB_DIR}/bin/$GNB_BINARY/gnb -i "GNB_TUN_$gnb_nodeid" -c "${GNB_DIR}/conf/$gnb_nodeid" --port_detect_start=1000 --port_detect_end=65535 --set-if-dump=on
 }
 
 stop_gnb() {
-	#kill -9 `cat ${GNB_DIR}/conf/$gnb_nodeid/gnb_es.pid`
-	#kill -9 `cat ${GNB_DIR}/conf/$gnb_nodeid/gnb.pid`
-	killall -9 gnb
-	killall -9 gnb_es
+    #kill -9 `cat ${GNB_DIR}/conf/$gnb_nodeid/gnb_es.pid`
+    #kill -9 `cat ${GNB_DIR}/conf/$gnb_nodeid/gnb.pid`
+    killall -9 gnb
+    killall -9 gnb_es
 }
 
 
 if [ -z "$gnb_op_cmd" ] || [ -z "$gnb_nodeid" ]; then
-	show_usage
-	exit;
+    show_usage
+    exit;
 fi
 
 
 if [ ! -d "${GNB_DIR}/conf/$gnb_nodeid" ]; then
-	echo "node '$gnb_nodeid' directory '${GNB_DIR}/conf/$gnb_nodeid' not found"
-	exit;
+    echo "node '$gnb_nodeid' directory '${GNB_DIR}/conf/$gnb_nodeid' not found"
+    exit;
 fi
 
 
 if [ "$gnb_op_cmd" = "stop" ] ; then
 
-	stop_gnb
+    stop_gnb
 
 elif [ "$gnb_op_cmd" = "restart" ]; then
 
-	stop_gnb
-	start_gnb
+    stop_gnb
+    start_gnb
 
 elif [ "$gnb_op_cmd" = "debug" ]; then
 
-	stop_gnb
-	debug_gnb
+    stop_gnb
+    debug_gnb
 
 elif [ "$gnb_op_cmd" = "start" ]; then
 
-	start_gnb
+    start_gnb
 
 elif [ "$gnb_op_cmd" = "start" ]; then
 
-	debug_gnb
+    debug_gnb
 
 fi
 

--- a/sh/gnb_openwrt_mt76x8.sh
+++ b/sh/gnb_openwrt_mt76x8.sh
@@ -22,67 +22,66 @@ GNB_BINARY=openwrt/ramips-mt76x8
 gnb_op_cmd=$1
 gnb_nodeid=$2
 
-
 show_usage(){
-   echo "usage: $0 start|stop|restart node"
-   echo "example: $0 start" 1001
-   echo "node located: [${GNB_DIR}/conf/]"
-   ls ${GNB_DIR}/conf/
+    echo "usage: $0 start|stop|restart node"
+    echo "example: $0 start" 1001
+    echo "node located: [${GNB_DIR}/conf/]"
+    ls ${GNB_DIR}/conf/
 }
 
 
 start_gnb() {
     nohup ${GNB_DIR}/bin/$GNB_BINARY/gnb_es -s -b "${GNB_DIR}/conf/$gnb_nodeid/gnb.map" --dump-address --upnp --pid-file=${GNB_DIR}/conf/$gnb_nodeid/gnb_es.pid    > /dev/null 2>&1 &
-	nohup ${GNB_DIR}/bin/$GNB_BINARY/gnb -i "GNB_TUN_$gnb_nodeid" -c "${GNB_DIR}/conf/$gnb_nodeid" --port_detect_start=1000 --port_detect_end=65535  > /dev/null 2>&1 &
+    nohup ${GNB_DIR}/bin/$GNB_BINARY/gnb -i "GNB_TUN_$gnb_nodeid" -c "${GNB_DIR}/conf/$gnb_nodeid" --port_detect_start=1000 --port_detect_end=65535  > /dev/null 2>&1 &
 }
 
 
 debug_gnb(){
     nohup ${GNB_DIR}/bin/$GNB_BINARY/gnb_es -s -b "${GNB_DIR}/conf/$gnb_nodeid/gnb.map" --dump-address --upnp     > /dev/null 2>&1 &
-	${GNB_DIR}/bin/$GNB_BINARY/gnb -i "GNB_TUN_$gnb_nodeid" -c "${GNB_DIR}/conf/$gnb_nodeid" --port_detect_start=1000 --port_detect_end=65535 --set-if-dump=on
+    ${GNB_DIR}/bin/$GNB_BINARY/gnb -i "GNB_TUN_$gnb_nodeid" -c "${GNB_DIR}/conf/$gnb_nodeid" --port_detect_start=1000 --port_detect_end=65535 --set-if-dump=on
 }
 
 stop_gnb() {
-	#kill -9 `cat ${GNB_DIR}/conf/$gnb_nodeid/gnb_es.pid`
-	#kill -9 `cat ${GNB_DIR}/conf/$gnb_nodeid/gnb.pid`
-	killall -9 gnb
-	killall -9 gnb_es
+    #kill -9 `cat ${GNB_DIR}/conf/$gnb_nodeid/gnb_es.pid`
+    #kill -9 `cat ${GNB_DIR}/conf/$gnb_nodeid/gnb.pid`
+    killall -9 gnb
+    killall -9 gnb_es
 }
 
 
 if [ -z "$gnb_op_cmd" ] || [ -z "$gnb_nodeid" ]; then
-	show_usage
-	exit;
+    show_usage
+    exit;
 fi
 
 
 if [ ! -d "${GNB_DIR}/conf/$gnb_nodeid" ]; then
-	echo "node '$gnb_nodeid' directory '${GNB_DIR}/conf/$gnb_nodeid' not found"
-	exit;
+    echo "node '$gnb_nodeid' directory '${GNB_DIR}/conf/$gnb_nodeid' not found"
+    exit;
 fi
 
 
 if [ "$gnb_op_cmd" = "stop" ] ; then
 
-	stop_gnb
+    stop_gnb
 
 elif [ "$gnb_op_cmd" = "restart" ]; then
 
-	stop_gnb
-	start_gnb
+    stop_gnb
+    start_gnb
 
 elif [ "$gnb_op_cmd" = "debug" ]; then
 
-	stop_gnb
-	debug_gnb
+    stop_gnb
+    debug_gnb
 
 elif [ "$gnb_op_cmd" = "start" ]; then
 
-	start_gnb
+    start_gnb
 
 elif [ "$gnb_op_cmd" = "start" ]; then
 
-	debug_gnb
+    debug_gnb
 
 fi
 

--- a/sh/gnb_openwrt_x86_64.sh
+++ b/sh/gnb_openwrt_x86_64.sh
@@ -21,67 +21,66 @@ GNB_BINARY=openwrt/x86_64
 gnb_op_cmd=$1
 gnb_nodeid=$2
 
-
 show_usage(){
-   echo "usage: $0 start|stop|restart node"
-   echo "example: $0 start" 1001
-   echo "node located: [${GNB_DIR}/conf/]"
-   ls ${GNB_DIR}/conf/
+    echo "usage: $0 start|stop|restart node"
+    echo "example: $0 start" 1001
+    echo "node located: [${GNB_DIR}/conf/]"
+    ls ${GNB_DIR}/conf/
 }
 
 
 start_gnb() {
     nohup ${GNB_DIR}/bin/$GNB_BINARY/gnb_es -s -b "${GNB_DIR}/conf/$gnb_nodeid/gnb.map" --dump-address --upnp --pid-file=${GNB_DIR}/conf/$gnb_nodeid/gnb_es.pid    > /dev/null 2>&1 &
-	nohup ${GNB_DIR}/bin/$GNB_BINARY/gnb -i "GNB_TUN_$gnb_nodeid" -c "${GNB_DIR}/conf/$gnb_nodeid" --port_detect_start=1000 --port_detect_end=65535  > /dev/null 2>&1 &
+    nohup ${GNB_DIR}/bin/$GNB_BINARY/gnb -i "GNB_TUN_$gnb_nodeid" -c "${GNB_DIR}/conf/$gnb_nodeid" --port_detect_start=1000 --port_detect_end=65535  > /dev/null 2>&1 &
 }
 
 
 debug_gnb(){
     nohup ${GNB_DIR}/bin/$GNB_BINARY/gnb_es -s -b "${GNB_DIR}/conf/$gnb_nodeid/gnb.map" --dump-address --upnp     > /dev/null 2>&1 &
-	${GNB_DIR}/bin/$GNB_BINARY/gnb -i "GNB_TUN_$gnb_nodeid" -c "${GNB_DIR}/conf/$gnb_nodeid" --port_detect_start=1000 --port_detect_end=65535 --set-if-dump=on
+    ${GNB_DIR}/bin/$GNB_BINARY/gnb -i "GNB_TUN_$gnb_nodeid" -c "${GNB_DIR}/conf/$gnb_nodeid" --port_detect_start=1000 --port_detect_end=65535 --set-if-dump=on
 }
 
 stop_gnb() {
-	#kill -9 `cat ${GNB_DIR}/conf/$gnb_nodeid/gnb_es.pid`
-	#kill -9 `cat ${GNB_DIR}/conf/$gnb_nodeid/gnb.pid`
-	killall -9 gnb
-	killall -9 gnb_es
+    #kill -9 `cat ${GNB_DIR}/conf/$gnb_nodeid/gnb_es.pid`
+    #kill -9 `cat ${GNB_DIR}/conf/$gnb_nodeid/gnb.pid`
+    killall -9 gnb
+    killall -9 gnb_es
 }
 
 
 if [ -z "$gnb_op_cmd" ] || [ -z "$gnb_nodeid" ]; then
-	show_usage
-	exit;
+    show_usage
+    exit;
 fi
 
 
 if [ ! -d "${GNB_DIR}/conf/$gnb_nodeid" ]; then
-	echo "node '$gnb_nodeid' directory '${GNB_DIR}/conf/$gnb_nodeid' not found"
-	exit;
+    echo "node '$gnb_nodeid' directory '${GNB_DIR}/conf/$gnb_nodeid' not found"
+    exit;
 fi
 
 
 if [ "$gnb_op_cmd" = "stop" ] ; then
 
-	stop_gnb
+    stop_gnb
 
 elif [ "$gnb_op_cmd" = "restart" ]; then
 
-	stop_gnb
-	start_gnb
+    stop_gnb
+    start_gnb
 
 elif [ "$gnb_op_cmd" = "debug" ]; then
 
-	stop_gnb
-	debug_gnb
+    stop_gnb
+    debug_gnb
 
 elif [ "$gnb_op_cmd" = "start" ]; then
 
-	start_gnb
+    start_gnb
 
 elif [ "$gnb_op_cmd" = "start" ]; then
 
-	debug_gnb
+    debug_gnb
 
 fi
 

--- a/sh/gnb_raspberrypi_ARMv7.sh
+++ b/sh/gnb_raspberrypi_ARMv7.sh
@@ -21,6 +21,10 @@ GNB_BINARY=raspberrypi_ARMv7
 gnb_op_cmd=$1
 gnb_nodeid=$2
 
+if [ "$USER" != "root" ]; then
+    sudo $0 $*
+    exit $?
+fi
 
 show_usage(){
    echo "usage: $0 start|stop|restart node"

--- a/sh/gnb_raspberrypi_ARMv7.sh
+++ b/sh/gnb_raspberrypi_ARMv7.sh
@@ -27,64 +27,64 @@ if [ "$USER" != "root" ]; then
 fi
 
 show_usage(){
-   echo "usage: $0 start|stop|restart node"
-   echo "example: $0 start" 1001
-   echo "node located: [${GNB_DIR}/conf/]"
-   ls ${GNB_DIR}/conf/
+    echo "usage: $0 start|stop|restart node"
+    echo "example: $0 start" 1001
+    echo "node located: [${GNB_DIR}/conf/]"
+    ls ${GNB_DIR}/conf/
 }
 
 
 start_gnb() {
     nohup ${GNB_DIR}/bin/$GNB_BINARY/gnb_es -s -b "${GNB_DIR}/conf/$gnb_nodeid/gnb.map" --dump-address --upnp --pid-file=${GNB_DIR}/conf/$gnb_nodeid/gnb_es.pid    > /dev/null 2>&1 &
-	nohup ${GNB_DIR}/bin/$GNB_BINARY/gnb -i "GNB_TUN_$gnb_nodeid" -c "${GNB_DIR}/conf/$gnb_nodeid" --port_detect_start=1000 --port_detect_end=65535  > /dev/null 2>&1 &
+    nohup ${GNB_DIR}/bin/$GNB_BINARY/gnb -i "GNB_TUN_$gnb_nodeid" -c "${GNB_DIR}/conf/$gnb_nodeid" --port_detect_start=1000 --port_detect_end=65535  > /dev/null 2>&1 &
 }
 
 
 debug_gnb(){
     nohup ${GNB_DIR}/bin/$GNB_BINARY/gnb_es -s -b "${GNB_DIR}/conf/$gnb_nodeid/gnb.map" --dump-address --upnp     > /dev/null 2>&1 &
-	${GNB_DIR}/bin/$GNB_BINARY/gnb -i "GNB_TUN_$gnb_nodeid" -c "${GNB_DIR}/conf/$gnb_nodeid" --port_detect_start=1000 --port_detect_end=65535 --set-if-dump=on
+    ${GNB_DIR}/bin/$GNB_BINARY/gnb -i "GNB_TUN_$gnb_nodeid" -c "${GNB_DIR}/conf/$gnb_nodeid" --port_detect_start=1000 --port_detect_end=65535 --set-if-dump=on
 }
 
 stop_gnb() {
-	#kill -9 `cat ${GNB_DIR}/conf/$gnb_nodeid/gnb_es.pid`
-	#kill -9 `cat ${GNB_DIR}/conf/$gnb_nodeid/gnb.pid`
-	killall -9 gnb
-	killall -9 gnb_es
+    #kill -9 `cat ${GNB_DIR}/conf/$gnb_nodeid/gnb_es.pid`
+    #kill -9 `cat ${GNB_DIR}/conf/$gnb_nodeid/gnb.pid`
+    killall -9 gnb
+    killall -9 gnb_es
 }
 
 if [ -z "$gnb_op_cmd" ] || [ -z "$gnb_nodeid" ]; then
-	show_usage
-	exit;
+    show_usage
+    exit;
 fi
 
 
 if [ ! -d "${GNB_DIR}/conf/$gnb_nodeid" ]; then
-	echo "node '$gnb_nodeid' directory '${GNB_DIR}/conf/$gnb_nodeid' not found"
-	exit;
+    echo "node '$gnb_nodeid' directory '${GNB_DIR}/conf/$gnb_nodeid' not found"
+    exit;
 fi
 
 
 if [ "$gnb_op_cmd" = "stop" ] ; then
 
-	stop_gnb
+    stop_gnb
 
 elif [ "$gnb_op_cmd" = "restart" ]; then
 
-	stop_gnb
-	start_gnb
+    stop_gnb
+    start_gnb
 
 elif [ "$gnb_op_cmd" = "debug" ]; then
 
-	stop_gnb
-	debug_gnb
+    stop_gnb
+    debug_gnb
 
 elif [ "$gnb_op_cmd" = "start" ]; then
 
-	start_gnb
+    start_gnb
 
 elif [ "$gnb_op_cmd" = "start" ]; then
 
-	debug_gnb
+    debug_gnb
 
 fi
 

--- a/sh/gnb_windows.cmd
+++ b/sh/gnb_windows.cmd
@@ -8,11 +8,13 @@ cd /d %~dp0
 set nodeid=%1
 
 if defined nodeid (
+
     echo nodeid is !nodeid!
+
 ) else (
 
     echo nodeid is NULL
-	goto FINISH
+    goto FINISH
 
 )
 


### PR DESCRIPTION
脚本运行前检测是否有root权限，如果没有，则自动使用sudo执行。同时，格式化了脚本文件，更整齐。macos上不能用nohup（有nohup命令），否则执行会失败。